### PR TITLE
Change DSP to Little Endian

### DIFF
--- a/src/VGAudio.Tests/Formats/GcAdpcmFormatTests.cs
+++ b/src/VGAudio.Tests/Formats/GcAdpcmFormatTests.cs
@@ -87,8 +87,8 @@ namespace VGAudio.Tests.Formats
         }
 
         [Theory]
-        [InlineData(Endianness.BigEndian)]
         [InlineData(Endianness.LittleEndian)]
+        [InlineData(Endianness.BigEndian)]
         public void BuildSeekTableOneChannel(Endianness endianness)
         {
             short[] expected = { 0, 0, 50, 49, 100, 99 };
@@ -98,8 +98,8 @@ namespace VGAudio.Tests.Formats
         }
 
         [Theory]
-        [InlineData(Endianness.BigEndian)]
         [InlineData(Endianness.LittleEndian)]
+        [InlineData(Endianness.BigEndian)]
         public void BuildSeekTableTwoChannels(Endianness endianness)
         {
             short[] expected = { 0, 0, 0, 0, 50, 49, 100, 99, 100, 99, 150, 149 };
@@ -109,8 +109,8 @@ namespace VGAudio.Tests.Formats
         }
 
         [Theory]
-        [InlineData(Endianness.BigEndian)]
         [InlineData(Endianness.LittleEndian)]
+        [InlineData(Endianness.BigEndian)]
         public void BuildSeekTableFourChannels(Endianness endianness)
         {
             short[] expected =
@@ -125,8 +125,8 @@ namespace VGAudio.Tests.Formats
         }
 
         [Theory]
-        [InlineData(Endianness.BigEndian)]
         [InlineData(Endianness.LittleEndian)]
+        [InlineData(Endianness.BigEndian)]
         public void BuildSeekTableFourChannelsTruncated(Endianness endianness)
         {
             short[] expected =

--- a/src/VGAudio/Containers/Dsp/DspWriter.cs
+++ b/src/VGAudio/Containers/Dsp/DspWriter.cs
@@ -43,7 +43,7 @@ namespace VGAudio.Containers.Dsp
         {
             //RecalculateData();
 
-            using (BinaryWriter writer = GetBinaryWriter(stream, Endianness.BigEndian))
+            using (BinaryWriter writer = GetBinaryWriter(stream, Endianness.LittleEndian))
             {
                 stream.Position = 0;
                 WriteHeader(writer);
@@ -65,7 +65,7 @@ namespace VGAudio.Containers.Dsp
                 writer.Write(StartAddr);
                 writer.Write(EndAddr);
                 writer.Write(CurAddr);
-                writer.Write(channel.Coefs.ToByteArray(Endianness.BigEndian));
+                writer.Write(channel.Coefs.ToByteArray(Endianness.LittleEndian));
                 writer.Write(channel.Gain);
                 channel.StartContext.Write(writer);
                 if (Adpcm.Looping)


### PR DESCRIPTION
Some Switch games are using this audio format, but they store headers data in Little Endian order.